### PR TITLE
fix empty prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const core = require('@actions/core');
 
 try {
     const fileName = core.getInput('filename', { required: true });
-    const prefix = core.getInput('prefix') || 'json';
+    const prefix = core.getInput('prefix');
     const masked = (core.getInput('masked') || 'false') === 'true';
 
     const fullPath = path.resolve(fileName);


### PR DESCRIPTION
it turned out that when you do not want a prefix, it always sets `json`